### PR TITLE
hw-probe.pl: disable automatic upload

### DIFF
--- a/hw-probe.pl
+++ b/hw-probe.pl
@@ -217,9 +217,14 @@ GetOptions("h|help!" => \$Opt{"Help"},
 
 if($#ARGV_COPY==-1)
 { # Run from STDIN
-    print "Executing hw-probe -all -upload\n\n";
-    $Opt{"All"} = 1;
-    $Opt{"Upload"} = 1;
+    if (-t STDIN) {
+        print "Executing hw-probe -help\n\n";
+        $Opt{"Help"} = 1;
+    } else {
+        print "Executing hw-probe -all -upload\n\n";
+        $Opt{"All"} = 1;
+        $Opt{"Upload"} = 1;
+    }
 }
 elsif($#ARGV_COPY==0 and grep { $ARGV_COPY[0] eq $_ } ("-snap", "-flatpak"))
 { # Run by desktop file


### PR DESCRIPTION
Due security concerns, running 'hw-probe.pl' without any parameters
shouldn't upload directly by default all data. Instead, the user should
add '-upload' if he really wants that.

Signed-off-by: Conrad Kostecki <conikost@gentoo.org>