### PR TITLE
Disable -upload when no arguments given to prevent suprise information sharing

### DIFF
--- a/hw-probe.pl
+++ b/hw-probe.pl
@@ -223,16 +223,14 @@ if($#ARGV_COPY==-1)
     }
     else
     {
-        print "Executing hw-probe -all -upload\n\n";
+        print "Executing hw-probe -all\n\n";
         $Opt{"All"} = 1;
-        $Opt{"Upload"} = 1;
     }
 }
 elsif($#ARGV_COPY==0 and grep { $ARGV_COPY[0] eq $_ } ("-snap", "-flatpak"))
 { # Run by desktop file
-    print "Executing hw-probe -all -upload\n\n";
+    print "Executing hw-probe -all\n\n";
     $Opt{"All"} = 1;
-    $Opt{"Upload"} = 1;
     
     if($SNAP_DESKTOP or $FLATPAK_DESKTOP)
     { # Desktop


### PR DESCRIPTION
Users that are cautious about their fingerprint should not accidentally upload their system contents by typing in just "hw-probe".
I expect just "hw-probe" to perform a probe and save the result to allow for inspection.
Programs should not default to pushing content online, no matter if it is anonymous or not.