### PR TITLE
Automatically generate and upload report by using systemd timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Contents
 * [ Live CD      ](#live-cd)
 * [ Snap         ](#snap)
 * [ Flatpak      ](#flatpak)
+* [ Periodic     ](#periodic)
 * [ Inventory    ](#inventory)
 * [ Offline view ](#offline-view)
 * [ ACPI dump    ](#acpi-dump)
@@ -102,6 +103,7 @@ The app runs on all 64-bit Linux distributions with `Glibc >= 2.14` including:
 * Gentoo 12 and newer
 * Sabayon 13 and newer
 * Slackware 14.2 and newer
+* OpenMandriva 3.0 and newer
 
 
 Docker
@@ -232,6 +234,28 @@ Need to setup Flatpak (https://flatpak.org/setup/):
 * Arch Linux
 * Chrome OS
 
+
+Periodic
+-------
+If your distribuition is running under systemd and you want to generate and upload
+hw-probe report automatically, please install as root:
+
+    cp -a periodic/*.{service,timer} $(systemdsystemunitdir)/
+
+Normally systemd units dir is located at `/usr/lib/systemd/system`
+You may want to get systemd unit dir by running
+`pkg-config --variable=systemdsystemunitdir systemd`
+
+Enable hw-probe.timer by running as root:
+
+    systemctl enable --now hw-probe.timer
+
+This timer will execute one time per month a hw-probe.service that will generate and 
+upload report to https://linux-hardware.org
+
+User may edit hw-probe.timer and change OnCalendar value to execute
+hw-probe report on different time period.
+Values lower than month are STRONGLY not recommended.
 
 Inventory
 ---------

--- a/periodic/hw-probe.service
+++ b/periodic/hw-probe.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Probe hardware and upload result to Linux hardware database
+ConditionVirtualization=false
+After=local-fs.target
+
+[Service]
+Type=idle
+ExecStart=/usr/bin/hw-probe -all -upload
+IOSchedulingClass=idle
+Nice=19
+IOSchedulingClass=2
+IOSchedulingPriority=7
+ProtectSystem=full
+StandardOutput=null

--- a/periodic/hw-probe.timer
+++ b/periodic/hw-probe.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Monthly hw-probe report
+
+[Timer]
+OnCalendar=monthly
+AccuracySec=12h
+Persistent=true
+OnBootSec=7min
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
I added systemd units to automate the process:
hw-probe.timer - executes hw-probe.service one time per month
hw-probe.service - runs `hw-probe -all -upload` under specific curcumstances (no virt env) and with secured environment

These files are not installed by default, because not everybody want to have upload some data without consent.