### PR TITLE
fix periodic service file

### DIFF
--- a/periodic/hw-probe.service
+++ b/periodic/hw-probe.service
@@ -4,7 +4,7 @@ ConditionVirtualization=false
 After=local-fs.target
 
 [Service]
-Type=idle
+Type=simple
 ExecStart=/usr/bin/hw-probe -all -upload
 IOSchedulingClass=idle
 Nice=19


### PR DESCRIPTION
This prevents to start hw-probe.service outside of hw-probe.timer.
Fix for https://github.com/linuxhw/hw-probe/pull/86