### PR TITLE
Add outgoing http/https proxy support

### DIFF
--- a/hw-probe.pl
+++ b/hw-probe.pl
@@ -167,6 +167,7 @@ GetOptions("h|help!" => \$Opt{"Help"},
   "upload|confirm-upload-of-hashed-ids!" => \$Opt{"Upload"},
   "hwinfo-path=s" => \$Opt{"HWInfoPath"},
   "log!" => \$Opt{"ShowLog"},
+  "proxy=s" => \$Opt{"Proxy"},
 # Inventory
   "inventory|inventory-id|i|group|g=s" => \$Opt{"Group"},
   "generate-inventory|generate-inventory-id|get-inventory-id|get-group!" => \$Opt{"GenerateGroup"},
@@ -354,6 +355,9 @@ GENERAL OPTIONS:
   
   -hwinfo-path PATH
       Path to a local hwinfo binary.
+
+  -proxy address:port
+      Set outgoing http/https proxy using syntax: proxy.domain.local:3128
 
 INVENTORY OPTIONS:
   -i|-inventory-id ID
@@ -2475,6 +2479,11 @@ sub postRequest($$$)
     require LWP::UserAgent;
     
     my $UAgent = LWP::UserAgent->new(parse_head => 0);
+
+    if($Opt{"Proxy"}) {
+        my $proxy = $Opt{"Proxy"};
+        $UAgent->proxy([ [ 'http', 'https' ] => "http://$proxy" ]);
+    }
     
     if($SSL eq "NoSSL" or not checkModule("Mozilla/CA.pm"))
     {


### PR DESCRIPTION
This PR adds support for setting an outgoing proxy where no direct Internet connection is available.
A proxy can be defined using the new parameter `-proxy`.

Without proxy:

```
# sudo -E hw-probe -all -upload                     
Probe for hardware ... Ok
Reading logs ... WARNING: X11-related logs are not collected (try to run 'xhost +local:' to enable access or run as root by su)
Ok
read failed: Connection reset by peer at /usr/share/perl5/LWP/Protocol/http.pm line 382.

ERROR: failed to upload data
```

With proxy:

```
# sudo -E hw-probe -all -upload -proxy proxy.example.com:3128
Probe for hardware ... Ok
Reading logs ... WARNING: X11-related logs are not collected (try to run 'xhost +local:' to enable access or run as root by su)
Ok
Uploaded to DB, Thank you!

Probe URL: https://linux-hardware.org/?probe=a35e7d3eb0
```