### PR TITLE
Changed port GhostBSDPortsVer by GhostBSDVer to use ghostbsd-version

### DIFF
--- a/hw-probe.pl
+++ b/hw-probe.pl
@@ -14433,22 +14433,21 @@ sub probeDistr()
                 $Name = "ghostbsd";
             }
             
-            my $GhostBSDPortsVer = "";
+            my $GhostBSDVer = "";
             if($Opt{"FixProbe"}) {
-                $GhostBSDPortsVer = readFile($FixProbe_Logs."/ports_ver");
+                $GhostBSDVer = readFile($FixProbe_Logs."/ghostbsd-version");
             }
             else
             {
-                if(checkCmd("pkg"))
+                if(checkCmd("ghostbsd-version"))
                 {
-                    $GhostBSDPortsVer = runCmd("pkg rquery \'\%v\' ports");
-                    chomp($GhostBSDPortsVer);
-                    writeLog($LOG_DIR."/ports_ver", $GhostBSDPortsVer);
+                    $GhostBSDVer = runCmd("ghostbsd-version");
+                    writeLog($LOG_DIR."/ghostbsd-version", $GhostBSDVer);
                 }
             }
             
-            if($GhostBSDPortsVer) {
-                $Release = $GhostBSDPortsVer;
+            if($GhostBSDVer) {
+                $Release = $GhostBSDVer;
             }
             
             # OPNsense

--- a/hw-probe.pl
+++ b/hw-probe.pl
@@ -14444,6 +14444,12 @@ sub probeDistr()
                     $GhostBSDVer = runCmd("ghostbsd-version");
                     writeLog($LOG_DIR."/ghostbsd-version", $GhostBSDVer);
                 }
+                elsif(checkCmd("pkg"))
+                {
+                    $GhostBSDVer = runCmd("pkg rquery \'\%v\' ports");
+                    chomp($GhostBSDVer);
+                    writeLog($LOG_DIR."/ghostbsd-version", $GhostBSDVer);
+                }
             }
             
             if($GhostBSDVer) {


### PR DESCRIPTION
I tested the change here is the results:
```
/u/h/e/p/e/hw-probe > sudo -E perl hw-probe.pl -all 
Probe for hardware ... Ok
Reading logs ... Ok
Local probe path: /root/HW_PROBE/LATEST/hw.info
 /u/h/e/p/e/hw-probe > cat /root/HW_PROBE/LATEST/hw.info/host
arch:amd64
boot_mode:EFI
cores:16
current_desktop:MATE
de:MATE
display_server:X11
dual_boot:0
dual_boot_win:0
filesystem:zfs
freebsd_release:13.0
freebsd_version:13.0-STABLE
hwaddr:5a97ae9b318126e34f71f12be6ea447e
kernel:13.0-STABLE
lang:en_US.UTF-8
microarch:Zen+
model:X470 AORUS ULTRA GAMING-CF
monitors:1
nics:1
part_scheme:GPT
probe_ver:1.6
ram_total:67108864
ram_used:1905664
sockets:1
space_total:327
space_used:54
submodel:X470 AORUS ULTRA GAMING
subvendor:Gigabyte Technology Co., Ltd.
system:ghostbsd-21.12.05
system_version:21.12.05
threads:1
type:desktop
uuid:76EA6BBF-D8CD-1EBF-C433-33798A4D7173
vendor:Gigabyte Technology Co., Ltd.
video_memory:4
year:2021
```
Resolves #98 