### PR TITLE
Check for MEGAcmd tool before running megacmd

### DIFF
--- a/hw-probe.pl
+++ b/hw-probe.pl
@@ -9329,12 +9329,15 @@ sub probeHW()
     {
         my $MegacliCmd = undef;
         
-        foreach my $Cmd ("megacli", "MegaCli64", "MegaCli")
+        if(not (checkCmd("mega-version")))
         {
-            if(checkCmd($Cmd))
+            foreach my $Cmd ("megacli", "MegaCli64", "MegaCli")
             {
-                $MegacliCmd = $Cmd;
-                last;
+                if(checkCmd($Cmd))
+                {
+                    $MegacliCmd = $Cmd;
+                    last;
+                }
             }
         }
         


### PR DESCRIPTION
The MEGAcmd tool provides a megacli command, without this PR hw-probe tries to run it as it happens to be named exactly the same as another command hw-probe uses and hangs indefinitely.

Fixes #134