### PR TITLE
Add `-T permissive` option to smartctl(8) for reading SMART data from some uncommon devices

### DIFF
--- a/hw-probe.pl
+++ b/hw-probe.pl
@@ -11199,7 +11199,7 @@ sub runSmartctl(@)
             $Cmd = $SmartctlCmd." -a \"".$Dev."\"";
         }
     }
-    
+    $Cmd .= " -T permissive";
     if($AddOpt) {
         $Cmd .= " ".$AddOpt;
     }


### PR DESCRIPTION
Such as this device:
https://linux-hardware.org/?probe=2d7cb9b44b&log=smartctl

And after adding `-T permissive`:
https://linux-hardware.org/?probe=e987f27a7a&log=smartctl
