### PR TITLE
Don't overwrite dmesg from /var/log/messages if the result is empty

### DIFF
--- a/hw-probe.pl
+++ b/hw-probe.pl
@@ -5514,8 +5514,11 @@ sub probeHW()
         {
             if(index($Dmesg, "] Command line:") == -1)
             {
-                $Dmesg = runCmd("grep -I ' kernel: \\[' $Messages | sed 's/.* kernel: \\[/\\[/g'");
-                $Dmesg=~s/(.|\n)+(\[    0.000000\] Linux version)/$2/g; # last boot only
+                $KernelMessages = runCmd("grep -I ' kernel: \\[' $Messages | sed 's/.* kernel: \\[/\\[/g'");
+                $KernelMessages=~s/(.|\n)+(\[    0.000000\] Linux version)/$2/g; # last boot only
+                if(length $KernelMessages) {
+                    $Dmesg = $KernelMessages;
+                }
             }
         }
         


### PR DESCRIPTION
In some cases, `/var/log/messages` exists but get flooded with non-kernel messages only, results in an empty `dmesg` log from hw-probe; don't use this empty result and still prefer the **dmesg(1)** output in such case.