### PR TITLE
Allow log type 'vmstat' being used on non-BSD platforms

### DIFF
--- a/hw-probe.pl
+++ b/hw-probe.pl
@@ -17437,6 +17437,7 @@ my %EnabledLog = (
         "iw_scan",
         "modinfo",
         "mount",
+        "vmstat",
         "neofetch",
         "numactl",
         "route",


### PR DESCRIPTION
I think the **vmstat(8)** output could also be useful on non-BSD systems, so I added this log type to be enabled when the user requested `-maximal` option.