### PR TITLE
Allow log type 'pstree' being used on BSD platforms

### DIFF
--- a/hw-probe.pl
+++ b/hw-probe.pl
@@ -17539,7 +17539,9 @@ my %EnabledLog_BSD = (
         "rc.conf",
         "sysinfo"
     ],
-    "optional" => []
+    "optional" => [
+        "pstree"
+    ]
 );
 
 sub completeEnabledLogs()


### PR DESCRIPTION
**pstree(1)** is available on BSD platforms, such as [sysutils/pstree for FreeBSD](https://www.freshports.org/sysutils/pstree/), and [sysutils/pstree for NetBSD](https://cdn.netbsd.org/pub/NetBSD/NetBSD-current/pkgsrc/sysutils/pstree/index.html); therefore the log type `pstree` should be available on BSD, at least in the `optional` group.