### PR TITLE
Don't add repo for Tumbleweed

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -347,7 +347,6 @@ openSUSE Leap 15.4:
 
 openSUSE Tumbleweed:
 
-    sudo zypper addrepo https://download.opensuse.org/repositories/hardware/openSUSE_Tumbleweed/ hardware
     sudo zypper install hw-probe
 
 


### PR DESCRIPTION
Don't add repo for Tumbleweed
because hw-probe is part of the main oss repo for 2 years.

Leap 15.5 also has it already.