### PR TITLE
Add bcachefs fs tracking

### DIFF
--- a/hw-probe.pl
+++ b/hw-probe.pl
@@ -10689,7 +10689,7 @@ sub probeHW()
                 next;
             }
             
-            if($Line=~/ (ext[234]|btrfs|xfs) / and index($Line, "/")==-1) {
+            if($Line=~/ (ext[234]|btrfs|xfs|bcachefs) / and index($Line, "/")==-1) {
                 $Sys{"Dual_boot"} = 1;
             }
         }
@@ -10861,7 +10861,7 @@ sub probeHW()
     
     if(not $Sys{"Filesystem"})
     {
-        my @Filesystems = ("btrfs", "jfs", "reiserfs", "xfs", "zfs", "aufs", "ext[234]", "overlay", "hammer2", "ufs", "ffs");
+        my @Filesystems = ("btrfs", "jfs", "reiserfs", "xfs", "zfs", "aufs", "ext[234]", "overlay", "hammer2", "ufs", "ffs", "bcachefs");
         
         LOOP: foreach my $Log ($Df, $Lsblk, $Findmnt)
         {


### PR DESCRIPTION
Further info on bcachefs: https://bcachefs.org/

- bcachefs has entered the stable kernel in 6.7.
- Some further mkfs/non-mount options, that could conceivably be tracked: number and type of disks in bcachefs and per target type, usage of options like --replicas, --erasure_code, --encrypted, compression.
- Since bcachefs does checksumming, recovered/non-recovered errors could also be tracked.