### PR TITLE
Non-EFI systems are misdetected as EFI

### DIFF
--- a/hw-probe.pl
+++ b/hw-probe.pl
@@ -9589,7 +9589,7 @@ sub probeHW()
         delete($Sys{"Secureboot"});
     }
     
-    if(-e $FixProbe_Logs."/boot_efi" or index($Dmesg, "] efi:")!=-1) {
+    if(-d "/sys/firmware/efi") {
         $Sys{"Boot_mode"} = "EFI";
     }
     else {


### PR DESCRIPTION
Currectly hw-probe detects an EFI system by checking either:
* presence of `/boot/efi` directory, or
* `efi:` line in kernel log.

Both methods however, are wrong, leading many non-EFI systems being misdetected.

For the presence of `/boot/efi` directory, it means the system may have a setup that **supports** booting via EFI; that doesn't necessarily means the running system was booted via EFI.

For the `efi:` line in kernel log, it only means the running Linux was configured to be EFI-aware. In fact, the `efi:` line of one of my system was:
```
[    0.000000] efi: UEFI not found.
```
Which actually indicates that EFI is **not** being used.

Remove both improper checkings, and check for `/sys/firmware/efi` directory instead.
