### PR TITLE
Hide IPX addresses from `ifconfig(8)` output

### DIFF
--- a/hw-probe.pl
+++ b/hw-probe.pl
@@ -13783,6 +13783,7 @@ sub probeHWaddr()
             $IFConfig = hideIPs($IFConfig);
             $IFConfig = encryptMACs($IFConfig);
             $IFConfig=~s/(inet6 |inet |netmask |broadcast )[^\s]+/$1\XXX/g;
+            $IFConfig=~s/(ipx .+ +)[^\s]+/$1\XXXXXXXX.XXXXXXXXXXXX/g;
             $IFConfig=~s/(ssid )(.+?)( channel)/$1...$3/g;
             
             if(isBSD())


### PR DESCRIPTION
IPX addresses should be hided, similar to hiding MAC addresses.

An IPX address have 2 parts, a 32-bit network number and a 48-bit node number. In most cases, the node number is simply the MAC address on the configured network interface.

I have submitted a probe with this change applied, so you can preview the result:
https://linux-hardware.org/?probe=1f5f82a980&log=ifconfig
