### PR TITLE
Update install instructions for openSUSE

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -351,13 +351,6 @@ On openSUSE Leap 15.5 and newer / Tumbleweed and derivatives (GeckoLinux, etc.):
 
     sudo zypper install hw-probe
 
-openSUSE Leap 15.4:
-
-    sudo zypper addrepo https://download.opensuse.org/repositories/hardware/openSUSE_Leap_15.4/ hardware
-    sudo zypper install hw-probe
-
-For other versions select and install an RPM package: https://software.opensuse.org/package/hw-probe
-
 
 Install on OpenVZ
 -----------------


### PR DESCRIPTION
openSUSE Leap 15.4 is EOL, the previous instructions no longer work.