### PR TITLE
Improving NixOS instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -337,6 +337,31 @@ Install on NixOS
 
 Use [Docker](README.md#docker) or [Flatpak](README.md#flatpak).
 
+Alternatively, a nixpkg is available:
+
+Via nix-shell:
+
+    nix-shell -p hw-probe
+
+Via nix-env:
+
+    nix-env -iA nixos.hw-probe
+
+Using flakes:
+
+    nix profile install nixpkgs#hw-probe
+
+Using configuration.nix
+
+    environment.systemPackages = [
+        pkgs.hw-probe
+    ];
+
+Using Home Manager:
+
+    { pkgs, ...}: {
+        home.packages = [ pkgs.jdk8 ];
+    }
 
 Install on OpenMandriva
 -----------------------

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -360,7 +360,7 @@ Using configuration.nix
 Using Home Manager:
 
     { pkgs, ...}: {
-        home.packages = [ pkgs.jdk8 ];
+        home.packages = [ pkgs.hw-probe ];
     }
 
 Install on OpenMandriva


### PR DESCRIPTION
I noticed that, although a derivation was available, your guide was telling NixOS users to use either Flatpak or Docker. If there is a reason for this, please tell me. If not, here's a patch!